### PR TITLE
Added commands for switching and getting dongle mode

### DIFF
--- a/arduino/arduino_nRF52840/arduino_nRF52840.ino
+++ b/arduino/arduino_nRF52840/arduino_nRF52840.ino
@@ -24,7 +24,7 @@
  * with a BF LE UART Friend. Lots of this code is from an Adafruit example.
  */
 
-//#define DEBUG // uncomment this line to see additional prints in Serial monitor
+#define DEBUG // uncomment this line to see additional prints in Serial monitor
 
 #define BLE_NAME "AceRK"
 #define ADD_NEW_DEV_PROCESS_TIMEOUT 30000 // in millseconds
@@ -41,7 +41,7 @@
   Adafruit_DotStar statusLED(1, 8, 6, DOTSTAR_BGR);
 #elif defined(_VARIANT_FEATHER52840_)
 //Adafruit feather nrf52840
-    #define USER_SW 7
+    #define USER_SW A4 // temp, my nano 33 ble setup
 
     #include <Adafruit_NeoPixel.h>
     Adafruit_NeoPixel statusLED = Adafruit_NeoPixel(1, PIN_NEOPIXEL, NEO_GRB + NEO_KHZ800);
@@ -222,11 +222,21 @@ void load_mode_file(){
   }
 }
 
-void change_mode() {
+void get_mode(char* myLine) {
+  if(ble_mode) {
+    at_response("BLE\n");  
+  } else {
+    at_response("Serial\n");
+  }
+}
+
+void change_mode(char* myLine) {
   #ifdef DEBUG
     Serial.print("Changing operating mode");
   #endif
-
+  
+  at_response("OK\n");
+  
   ble_mode = !ble_mode;
 
   file.open(MODE_FILENAME, FILE_O_WRITE);
@@ -855,7 +865,9 @@ const command_action_t commands[] = {
     {"at+switchconn", switchBleConnection},
     {"at+printdevlist", printBleDevList},
     {"at+blemaxdevlistsize", setBleMaxDevListSize},
-    {"at+resetdevlist", deleteDevList}
+    {"at+resetdevlist", deleteDevList},
+    {"at+switchmode", change_mode},
+    {"at+getmode", get_mode},
 };
 
 void update_connections(uint16_t conn_handle){
@@ -967,7 +979,7 @@ void loop()
     if(detect_click() == 1){      
       addNewBleDevice("");
     } else {
-      change_mode();
+      change_mode("");
     }
   }
 

--- a/arduino/arduino_nRF52840/arduino_nRF52840.ino
+++ b/arduino/arduino_nRF52840/arduino_nRF52840.ino
@@ -24,7 +24,7 @@
  * with a BF LE UART Friend. Lots of this code is from an Adafruit example.
  */
 
-#define DEBUG // uncomment this line to see additional prints in Serial monitor
+//#define DEBUG // uncomment this line to see additional prints in Serial monitor
 
 #define BLE_NAME "AceRK"
 #define ADD_NEW_DEV_PROCESS_TIMEOUT 30000 // in millseconds
@@ -41,7 +41,7 @@
   Adafruit_DotStar statusLED(1, 8, 6, DOTSTAR_BGR);
 #elif defined(_VARIANT_FEATHER52840_)
 //Adafruit feather nrf52840
-    #define USER_SW A4 // temp, my nano 33 ble setup
+    #define USER_SW 7
 
     #include <Adafruit_NeoPixel.h>
     Adafruit_NeoPixel statusLED = Adafruit_NeoPixel(1, PIN_NEOPIXEL, NEO_GRB + NEO_KHZ800);

--- a/blehid.py
+++ b/blehid.py
@@ -352,3 +352,13 @@ async def blehid_get_at_response(ser):
     await _write_atcmd(ser, "AT")
     
     return await _read_response(ser)
+
+async def blehid_get_mode(ser):
+    logging.debug('Get dongle mode')
+    await _write_atcmd(ser, "AT+GETMODE")
+
+    return await _read_response(ser)
+
+async def blehid_switch_mode(ser):
+    logging.debug('Switch dongle mode')
+    await _write_atcmd(ser, "AT+SWITCHMODE")

--- a/relaykeys-qt.py
+++ b/relaykeys-qt.py
@@ -840,6 +840,9 @@ class Window (QMainWindow):
 
     @pyqtSlot()
     def switchDaemonMode(self):
+        if self.dongle_status == "Connected":
+            self.client_send_action("ble_cmd", "switch_mode")
+        
         self.client_send_action("daemon", "switch_mode")
         self.updateStatusCallback()
 

--- a/relaykeysd.py
+++ b/relaykeysd.py
@@ -57,7 +57,8 @@ UART_TX_CHAR_UUID = "6E400003-B5A3-F393-E0A9-E50E24DCCA9E"
 from blehid import blehid_send_keyboardcode, blehid_init_serial, \
     blehid_send_movemouse, blehid_send_mousebutton, blehid_send_devicecommand, \
     blehid_send_switch_command, blehid_send_get_device_name, blehid_get_device_list, \
-    blehid_send_add_device, blehid_send_clear_device_list, blehid_send_remove_device, blehid_get_at_response
+    blehid_send_add_device, blehid_send_clear_device_list, blehid_send_remove_device, \
+    blehid_get_at_response, blehid_get_mode, blehid_switch_mode
 
 import requests
 import json
@@ -578,7 +579,13 @@ async def process_action(ser, keys, cmd):
 
             elif cmd[1].split("=")[0] == "devremove":
                 await blehid_send_remove_device(ser, cmd[1])
-            
+
+            elif cmd[1] == "get_mode":
+                return await blehid_get_mode(ser)
+
+            elif cmd[1] == "switch_mode":
+                await blehid_switch_mode(ser)
+
         elif cmd[0] == "check_dongle":
             return await blehid_get_at_response(ser)
 


### PR DESCRIPTION
In this pull request were added commands for switching and getting dongle mode. #127

New AT commands:
AT+GETMODE
AT+SWITCHMODE

New CLI commands:
relaykeys-cli.py ble_cmd:get_mode   
relaykeys-cli.py ble_cmd:switch_mode 

RelayKeys QT:
If user presses "Switch mode" button and there is connection with dongle then QT app sends command to switch dongle mode besides sending switch daemon mode.